### PR TITLE
Set basePath config

### DIFF
--- a/ng2-ace-editor.ts
+++ b/ng2-ace-editor.ts
@@ -5,4 +5,4 @@ import {AceEditorModule} from './src/module';
 export {AceEditorModule, AceEditorDirective, AceEditorComponent};
 
 declare var ace: any;
-ace.config.set('basePath', 'node_modules/ace-builds/src/');
+ace.config.set('basePath', 'node_modules/ace-builds/src-min/');

--- a/ng2-ace-editor.ts
+++ b/ng2-ace-editor.ts
@@ -3,3 +3,6 @@ import {AceEditorComponent} from './src/component';
 import {AceEditorModule} from './src/module';
 
 export {AceEditorModule, AceEditorDirective, AceEditorComponent};
+
+declare var ace: any;
+ace.config.set('basePath', 'node_modules/ace-builds/src/');


### PR DESCRIPTION
When setting the editor mode to json, ace tries to load /mode-json.js
Setting basePath config fixes the issue.
Tested with angular cli