### PR TITLE
Implement ControlValueAccessor to support ngModel

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@angular/core": "2.0.0",
+    "@angular/forms": "2.0.0",
     "@types/hammerjs": "2.0.32",
     "@types/jasmine": "2.2.33",
     "@types/node": "6.0.38",


### PR DESCRIPTION
Added @angular/forms as a dependency, and implemented ControlValueAccessor on the component.

Purpose: you can now use `[(ngModel)]` to access the control's value, just like any native HTML input element. Example:

```
<ace-editor [(ngModel)]="myCode"></ace-editor>
```

**note:** I didn't commit any .js or .d.ts files, although they changed. This PR will not cause any conflicts with the other PR that I created today; they can be applied simultaneously or one at a time and it shouldn't make a difference.