### PR TITLE
Remove html brace definition as a default

### DIFF
--- a/dist/src/component.d.ts
+++ b/dist/src/component.d.ts
@@ -2,7 +2,6 @@ import { EventEmitter, ElementRef, OnInit, OnDestroy, NgZone } from "@angular/co
 import { ControlValueAccessor } from "@angular/forms";
 import "brace";
 import "brace/theme/monokai";
-import "brace/mode/html";
 export declare class AceEditorComponent implements ControlValueAccessor, OnInit, OnDestroy {
     private zone;
     textChanged: EventEmitter<{}>;

--- a/dist/src/component.js
+++ b/dist/src/component.js
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Output, ElementRef, Input, forwardRef, NgZone 
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 import "brace";
 import "brace/theme/monokai";
-import "brace/mode/html";
+
 var AceEditorComponent = /** @class */ (function () {
     function AceEditorComponent(elementRef, zone) {
         var _this = this;

--- a/dist/src/directive.d.ts
+++ b/dist/src/directive.d.ts
@@ -1,7 +1,7 @@
 import { EventEmitter, ElementRef, OnInit, OnDestroy, NgZone } from "@angular/core";
 import "brace";
 import "brace/theme/monokai";
-import "brace/mode/html";
+
 export declare class AceEditorDirective implements OnInit, OnDestroy {
     private zone;
     textChanged: EventEmitter<{}>;

--- a/dist/src/directive.js
+++ b/dist/src/directive.js
@@ -1,7 +1,7 @@
 import { Directive, EventEmitter, Output, ElementRef, Input, NgZone } from "@angular/core";
 import "brace";
 import "brace/theme/monokai";
-import "brace/mode/html";
+
 var AceEditorDirective = /** @class */ (function () {
     function AceEditorDirective(elementRef, zone) {
         var _this = this;

--- a/src/component.ts
+++ b/src/component.ts
@@ -2,7 +2,6 @@ import { Component, EventEmitter, Output, ElementRef, Input, forwardRef, OnInit,
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from "@angular/forms";
 import "brace";
 import "brace/theme/monokai";
-import "brace/mode/html";
 
 declare var ace: any;
 

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -1,7 +1,7 @@
 import { Directive, EventEmitter, Output, ElementRef, Input, OnInit, OnDestroy, NgZone } from "@angular/core";
 import "brace";
 import "brace/theme/monokai";
-import "brace/mode/html";
+
 
 declare var ace: any;
 


### PR DESCRIPTION
Currently ng2-ace-editor imports html mode by default. If a user of the component doesn't need html mode it still pulls it in, inflating the bundle size. I suggest bumping the major version after this commit so that existing users aren't impacted.